### PR TITLE
Azure integration

### DIFF
--- a/.github/workflows/azure_deploy_image.yml
+++ b/.github/workflows/azure_deploy_image.yml
@@ -1,0 +1,83 @@
+name: deploy-only
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag a desplegar (latest, vX.Y, o SHA)"
+        required: false
+        default: latest
+      wait_ssh:
+        description: "Esperar SSH antes de desplegar"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  packages: read   # necesario si usás GHCR
+
+env:
+  SSH_HOST: ${{ secrets.SSH_HOST }}
+  SSH_USER: ${{ secrets.SSH_USER }}
+  SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
+
+  # ===== Registro e imagen (por defecto GHCR) =====
+  IMAGE_NAME: ghcr.io/${{ github.repository }}/app
+  REGISTRY: ghcr.io
+  REG_USER: ${{ github.actor }}
+  REG_TOKEN: ${{ secrets.GHCR_RO_TOKEN || secrets.GITHUB_TOKEN }}
+
+jobs:
+  maybe_wait_ssh:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.wait_ssh }}
+    steps:
+      - name: Esperar SSH
+        run: |
+          echo "Esperando SSH en ${{ env.SSH_HOST }}:${{ env.SSH_PORT }} ..."
+          for i in {1..60}; do
+            if nc -z ${{ env.SSH_HOST }} ${{ env.SSH_PORT }}; then
+              echo "SSH arriba."; exit 0
+            fi
+            sleep 5
+          done
+          echo "Timeout esperando SSH." && exit 1
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [maybe_wait_ssh]
+    steps:
+      # (opcional) login en el runner si querés usar docker tooling local
+      - name: Login en registro (opcional)
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ env.REG_USER }}
+          password: ${{ env.REG_TOKEN }}
+
+      - name: Desplegar por SSH (docker compose)
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ env.SSH_HOST }}
+          username: ${{ env.SSH_USER }}
+          port: ${{ env.SSH_PORT }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            set -euo pipefail
+            TAG="${{ github.event.inputs.tag || 'latest' }}"
+            IMAGE="${{ env.IMAGE_NAME }}:${TAG}"
+
+            echo "${{ env.REG_TOKEN }}" | docker login ${{ env.REGISTRY }} -u "${{ env.REG_USER }}" --password-stdin
+
+            cd /opt/app
+            # Forzar la imagen/tag deseados en el compose:
+            sed -i "s#^\(\s*image:\s*\).*#\1${IMAGE}#g" docker-compose.yml
+
+            echo "Pull de la nueva imagen…"
+            docker pull "${IMAGE}" || true
+            docker compose pull || true
+
+            echo "Levantar/actualizar servicio…"
+            docker compose up -d --remove-orphans
+
+            echo "Limpieza de imágenes viejas…"
+            docker image prune -af || true

--- a/.github/workflows/azure_start_vm.yml
+++ b/.github/workflows/azure_start_vm.yml
@@ -1,0 +1,21 @@
+name: azure-vm-start
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  start:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Start VM
+        run: |
+          az vm start \
+            --name "${{ secrets.AZURE_VM_NAME }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}"

--- a/.github/workflows/azure_stop_vm.yml
+++ b/.github/workflows/azure_stop_vm.yml
@@ -1,0 +1,32 @@
+name: azure-vm-stop
+on:
+  workflow_dispatch:
+    inputs:
+      deallocate:
+        description: "Usar deallocate (recomendado para dejar de pagar compute)"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  stop:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Stop/Deallocate VM
+        run: |
+          if [ "${{ inputs.deallocate }}" = "true" ]; then
+            az vm deallocate \
+              --name "${{ secrets.AZURE_VM_NAME }}" \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}"
+          else
+            az vm stop \
+              --name "${{ secrets.AZURE_VM_NAME }}" \
+              --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}"
+          fi

--- a/.github/workflows/ghcr_deploy_docker_image.yml
+++ b/.github/workflows/ghcr_deploy_docker_image.yml
@@ -1,0 +1,40 @@
+name: build-and-publish-docker-image
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag de la imagen (ej. v1.2.3)"
+        required: false
+        default: latest
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set tags
+        id: t
+        run: |
+          echo "image=ghcr.io/${{ github.repository }}" >> $GITHUB_OUTPUT
+          echo "tag=${{ github.event.inputs.tag || 'latest' }}" >> $GITHUB_OUTPUT
+
+      - name: Build & Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.t.outputs.image }}:${{ steps.t.outputs.tag }}
+            ${{ steps.t.outputs.image }}:${{ github.sha }}


### PR DESCRIPTION
This pull request adds several new GitHub Actions workflows to automate common deployment and infrastructure tasks for the project. The main changes include workflows for starting and stopping Azure VMs, building and publishing Docker images to GHCR, and deploying images to remote servers via SSH with Docker Compose. These workflows improve the team's ability to manage infrastructure and application deployments directly from GitHub.

**Infrastructure automation:**

* Added `.github/workflows/azure_start_vm.yml` workflow to start an Azure VM using the Azure CLI and credentials stored in GitHub secrets.
* Added `.github/workflows/azure_stop_vm.yml` workflow to stop or deallocate an Azure VM, with an option to fully deallocate and stop billing for compute resources.

**Docker image build and deployment:**

* Added `.github/workflows/ghcr_deploy_docker_image.yml` workflow to build a Docker image from the repository, tag it, and push it to GitHub Container Registry (GHCR).
* Added `.github/workflows/azure_deploy_image.yml` workflow to deploy a Docker image to a remote server using SSH and Docker Compose, with optional SSH wait and automatic cleanup of old images.