### PR TITLE
Fix GitHub Actions workflow for Docker image deployment

### DIFF
--- a/.github/workflows/ghcr_deploy_docker_image.yml
+++ b/.github/workflows/ghcr_deploy_docker_image.yml
@@ -28,10 +28,10 @@ jobs:
         id: tags
         run: |
           REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          IMAGE="ghcr.io/${REPO_LC}"
+          IMAGE="ghcr.io/${REPO_LC}
           TAG="${{ github.event.inputs.tag || 'latest' }}"
-          echo "image=$IMAGE" >> $GITHUB_OUTPUT
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG"     >> "$GITHUB_OUTPUT"
 
       - name: Build & Push
         uses: docker/build-push-action@v6
@@ -39,5 +39,5 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ steps.t.outputs.image }}:${{ steps.t.outputs.tag }}
-            ${{ steps.t.outputs.image }}:${{ github.sha }}
+            ${{ steps.tags.outputs.image }}:${{ steps.tags.outputs.tag }}
+            ${{ steps.tags.outputs.image }}:${{ github.sha }}


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow for deploying Docker images. The main change is a correction in the variable naming and output handling in the `ghcr_deploy_docker_image.yml` workflow file to ensure consistency and proper functioning.

* Workflow variable naming: Changed references from `steps.t.outputs` to `steps.tags.outputs` in the Docker build and push step to match the correct step ID.
* Output formatting: Updated output redirection syntax to use quotes for `$GITHUB_OUTPUT` and fixed whitespace for consistency.