### PR TITLE
Fix syntax error in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ghcr_deploy_docker_image.yml
+++ b/.github/workflows/ghcr_deploy_docker_image.yml
@@ -28,7 +28,7 @@ jobs:
         id: tags
         run: |
           REPO_LC=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          IMAGE="ghcr.io/${REPO_LC}
+          IMAGE="ghcr.io/${REPO_LC}"
           TAG="${{ github.event.inputs.tag || 'latest' }}"
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG"     >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This pull request makes a minor fix to the Docker image deployment workflow by correcting a syntax error in the image name assignment.

* Fixed a missing closing quote in the assignment of the `IMAGE` variable in `.github/workflows/ghcr_deploy_docker_image.yml` to ensure the Docker image name is set correctly.