### PR TITLE
Add build arguments to GitHub Actions

### DIFF
--- a/.github/workflows/ghcr_deploy_docker_image.yml
+++ b/.github/workflows/ghcr_deploy_docker_image.yml
@@ -37,6 +37,9 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          build-args: |
+            GITHUB_ACTOR=${{ github.actor }}
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           push: true
           tags: |
             ${{ steps.tags.outputs.image }}:${{ steps.tags.outputs.tag }}


### PR DESCRIPTION
This pull request makes a small adjustment to the Docker image deployment workflow. The change adds build arguments for `GITHUB_ACTOR` and `GITHUB_TOKEN` to the Docker build step, which can be used within the Dockerfile for authentication or metadata purposes.