### PR TITLE
Refactor Azure deployment workflow

### DIFF
--- a/.github/workflows/azure_deploy_image.yml
+++ b/.github/workflows/azure_deploy_image.yml
@@ -13,18 +13,13 @@ on:
 
 permissions:
   contents: read
-  packages: read   # necesario si usás GHCR
+  packages: read
 
 env:
   SSH_HOST: ${{ secrets.SSH_HOST }}
   SSH_USER: ${{ secrets.SSH_USER }}
   SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
-
-  # ===== Registro e imagen (por defecto GHCR) =====
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/app
-  REGISTRY: ghcr.io
-  REG_USER: ${{ github.actor }}
-  REG_TOKEN: ${{ secrets.GHCR_RO_TOKEN || secrets.GITHUB_TOKEN }}
+  DEPLOY_DIR: /opt/app
 
 jobs:
   maybe_wait_ssh:
@@ -46,15 +41,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [maybe_wait_ssh]
     steps:
-      # (opcional) login en el runner si querés usar docker tooling local
-      - name: Login en registro (opcional)
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ env.REG_USER }}
-          password: ${{ env.REG_TOKEN }}
+      - name: Calcular imagen (lowercase GHCR)
+        id: img
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO_LC="$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')"
+          echo "image=ghcr.io/${REPO_LC}" >> "$GITHUB_OUTPUT"
+          echo "tag=${{ github.event.inputs.tag || 'latest' }}" >> "$GITHUB_OUTPUT"
 
-      - name: Desplegar por SSH (docker compose)
+      - name: Desplegar por SSH
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ env.SSH_HOST }}
@@ -63,21 +59,18 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           script: |
             set -euo pipefail
-            TAG="${{ github.event.inputs.tag || 'latest' }}"
-            IMAGE="${{ env.IMAGE_NAME }}:${TAG}"
+            IMAGE="${{ steps.img.outputs.image }}"
+            TAG="${{ steps.img.outputs.tag }}"
 
-            echo "${{ env.REG_TOKEN }}" | docker login ${{ env.REGISTRY }} -u "${{ env.REG_USER }}" --password-stdin
+            sudo mkdir -p "${{ env.DEPLOY_DIR }}"
+            cd "${{ env.DEPLOY_DIR }}"
 
-            cd /opt/app
-            # Forzar la imagen/tag deseados en el compose:
-            sed -i "s#^\(\s*image:\s*\).*#\1${IMAGE}#g" docker-compose.yml
+            # Login GHCR con PAT (read:packages)
+            echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
-            echo "Pull de la nueva imagen…"
-            docker pull "${IMAGE}" || true
-            docker compose pull || true
+            export IMAGE="$IMAGE"
+            export TAG="$TAG"
 
-            echo "Levantar/actualizar servicio…"
-            docker compose up -d --remove-orphans
-
-            echo "Limpieza de imágenes viejas…"
+            docker compose -f deploy-compose.yml pull
+            docker compose -f deploy-compose.yml up -d --remove-orphans
             docker image prune -af || true


### PR DESCRIPTION
This pull request updates the Azure deployment workflow to improve image handling and deployment consistency. The main changes include refactoring how the Docker image name and tag are calculated, switching to a dedicated deployment directory, and updating the SSH deployment step to use a more robust approach for pulling and running containers.

**Image and deployment handling improvements:**

* The Docker image name is now calculated dynamically and converted to lowercase to ensure compatibility with GHCR naming conventions. The tag is set based on workflow input or defaults to `latest`.
* The deployment directory is now explicitly set using the new `DEPLOY_DIR` environment variable, replacing hardcoded paths.

**SSH deployment step updates:**

* The workflow now uses a dedicated Personal Access Token (`GHCR_PAT`) for GHCR login, improving security and reliability.
* Deployment commands now reference `deploy-compose.yml` and use environment variables for image and tag, ensuring the correct image is pulled and run. Old images are pruned after deployment.

**Cleanup and simplification:**

* Removed optional Docker registry login and legacy image/tag handling, simplifying the workflow and reducing potential confusion. [[1]](diffhunk://#diff-d55c4e9e323e09b1846200bdf51f16c83f401acb5d3da267ef6ef3e0a037a635L49-R53) [[2]](diffhunk://#diff-d55c4e9e323e09b1846200bdf51f16c83f401acb5d3da267ef6ef3e0a037a635L16-R22)