### PR TITLE
Add workflow_call support 

### DIFF
--- a/.github/workflows/azure_deploy_image.yml
+++ b/.github/workflows/azure_deploy_image.yml
@@ -10,6 +10,15 @@ on:
         description: "Esperar SSH antes de desplegar"
         type: boolean
         default: true
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: latest
+      wait_ssh:
+        type: boolean
+        default: true
 
 permissions:
   contents: read

--- a/.github/workflows/azure_start_vm.yml
+++ b/.github/workflows/azure_start_vm.yml
@@ -1,6 +1,7 @@
 name: azure-vm-start
 on:
   workflow_dispatch: {}
+  workflow_call: {}
 
 permissions:
   contents: read

--- a/.github/workflows/azure_stop_vm.yml
+++ b/.github/workflows/azure_stop_vm.yml
@@ -6,6 +6,11 @@ on:
         description: "Usar deallocate (recomendado para dejar de pagar compute)"
         type: boolean
         default: true
+  workflow_call:
+    inputs:
+      deallocate:
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -30,3 +35,4 @@ jobs:
               --name "${{ secrets.AZURE_VM_NAME }}" \
               --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}"
           fi
+

--- a/.github/workflows/ghcr_deploy_docker_image.yml
+++ b/.github/workflows/ghcr_deploy_docker_image.yml
@@ -6,6 +6,12 @@ on:
         description: "Tag de la imagen (ej. v1.2.3)"
         required: false
         default: latest
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: latest
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@ name: Publish Packages
 
 on:
   workflow_dispatch: {}
+  workflow_call: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to support being triggered by other workflows using the `workflow_call` event. This enables modular and reusable CI/CD pipelines, allowing workflows to be invoked programmatically and with input parameters.

Workflow modularization:

* Added `workflow_call` support to `.github/workflows/azure_deploy_image.yml`, `.github/workflows/azure_start_vm.yml`, `.github/workflows/azure_stop_vm.yml`, `.github/workflows/ghcr_deploy_docker_image.yml`, and `.github/workflows/publish.yml`, allowing these workflows to be triggered from other workflows. [[1]](diffhunk://#diff-d55c4e9e323e09b1846200bdf51f16c83f401acb5d3da267ef6ef3e0a037a635R13-R21) [[2]](diffhunk://#diff-2aff27fce61828e5ac3c4dff9fa5e0d3032d8b1e7c55440008e0dbcd59d4be33R4) [[3]](diffhunk://#diff-e97b8570f48361df6f84c269661231dcbf8430f883a1572baff1a27857f7281dR9-R13) [[4]](diffhunk://#diff-e28486516f68a7790b93917a3edf96691f77bf30fe3929b73e0464dc4b64256dR9-R14) [[5]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R5)

Parameterization for workflow inputs:

* Defined input parameters for `workflow_call` in `.github/workflows/azure_deploy_image.yml` (`tag`, `wait_ssh`), `.github/workflows/azure_stop_vm.yml` (`deallocate`), and `.github/workflows/ghcr_deploy_docker_image.yml` (`tag`), making these workflows configurable when invoked. [[1]](diffhunk://#diff-d55c4e9e323e09b1846200bdf51f16c83f401acb5d3da267ef6ef3e0a037a635R13-R21) [[2]](diffhunk://#diff-e97b8570f48361df6f84c269661231dcbf8430f883a1572baff1a27857f7281dR9-R13) [[3]](diffhunk://#diff-e28486516f68a7790b93917a3edf96691f77bf30fe3929b73e0464dc4b64256dR9-R14)

Minor formatting change:

* Added a blank line at the end of the `jobs` section in `.github/workflows/azure_stop_vm.yml` for improved readability.