### PR TITLE
Refactor tag comparison logic in new version workflow

### DIFF
--- a/.github/workflows/new_version_workflow.yml
+++ b/.github/workflows/new_version_workflow.yml
@@ -34,11 +34,12 @@ jobs:
           set -euo pipefail
           BEFORE="${{ github.event.before }}"
           AFTER="${{ github.sha }}"
-
+          
           mapfile -t TAGS_AFTER < <(git tag --merged "$AFTER" --list 'v*' | sort -V)
           mapfile -t TAGS_BEFORE < <(git tag --merged "$BEFORE" --list 'v*' | sort -V)
-
-          NEW=$(comm -13 <(printf "%s\n" "${TAGS_BEFORE[@]+"${TAGS_BEFORE[@]}"})" <(printf "%s\n" "${TAGS_AFTER[@]}") | sort -V | tail -n1 || true)
+          
+          NEW=$(comm -13 <(printf "%s\n" "${TAGS_BEFORE[@]+"${TAGS_BEFORE[@]}"}" | sort -V) <(printf "%s\n" "${TAGS_AFTER[@]}" | sort -V) | tail -n1 || true)
+          
           if [[ -n "$NEW" ]]; then
             echo "New tag reachable in main: $NEW"
             echo "tag=$NEW" >> "$GITHUB_OUTPUT"
@@ -69,6 +70,7 @@ jobs:
 
   deploy-image-in-vm:
     needs:
+      - publish-image
       - start-vm
       - detect-tag
     if: ${{ needs.detect-tag.outputs.tag != '' }}


### PR DESCRIPTION
This pull request makes minor updates to the `.github/workflows/new_version_workflow.yml` workflow file, focusing on improving the detection of new tags and ensuring proper job dependencies.

*Improved tag detection logic:*

* The command for finding new tags now sorts both the "before" and "after" tag lists before comparing them. This makes the comparison more accurate and reliable.

*Workflow dependency updates:*

* The `deploy-image-in-vm` job now explicitly depends on the `publish-image` job, ensuring that the image is published before deployment proceeds.