### PR TITLE
Enhance Azure workflows

### DIFF
--- a/.github/workflows/azure_start_vm.yml
+++ b/.github/workflows/azure_start_vm.yml
@@ -1,7 +1,11 @@
 name: azure-vm-start
 on:
   workflow_dispatch: {}
-  workflow_call: {}
+  workflow_call:
+    outputs:
+      pre_status:
+        description: "Power state before start"
+        value: ${{ jobs.start.outputs.pre_status }}
 
 permissions:
   contents: read
@@ -14,6 +18,18 @@ jobs:
         uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Get pre-start status
+        id: get_pre
+        run: |
+          set -euo pipefail
+          STATUS=$(az vm get-instance-view \
+            --name "${{ secrets.AZURE_VM_NAME }}" \
+            --resource-group "${{ secrets.AZURE_RESOURCE_GROUP }}" \
+            --query "instanceView.statuses[?starts_with(code, 'PowerState/')].displayStatus" \
+            -o tsv)
+          echo "VM status before start: $STATUS"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
 
       - name: Start VM
         run: |

--- a/.github/workflows/new_version_workflow.yml
+++ b/.github/workflows/new_version_workflow.yml
@@ -84,8 +84,9 @@ jobs:
 
   shut-down-vm:
     needs:
+      - start-vm
       - deploy-image-in-vm
       - detect-tag
-    if: ${{ needs.detect-tag.outputs.tag != '' && (github.event_name == 'workflow_dispatch' && inputs.shut_down_vm_after) }}
+    if: ${{ (needs.detect-tag.outputs.tag != '' && (github.event_name == 'workflow_dispatch' && inputs.shut_down_vm_after)) || (github.event_name == 'push' && needs.start-vm.outputs.pre_status == 'VM deallocated') }}
     uses: ./.github/workflows/azure_stop_vm.yml
     secrets: inherit


### PR DESCRIPTION
This pull request makes improvements to the Azure VM start workflow and enhances conditional logic for shutting down VMs in the new version workflow. The main changes include exposing the VM's pre-start power state as an output in the workflow and updating downstream logic to use this information for more robust automation.

**Workflow output and status handling:**

* Exposed the VM's power state before starting as an output (`pre_status`) in the `azure_start_vm.yml` workflow, making it available for downstream workflows.
* Added a step to retrieve and output the VM's pre-start status using Azure CLI in the `azure_start_vm.yml` workflow.

**Conditional workflow logic:**

* Updated the shutdown logic in `new_version_workflow.yml` to also trigger a VM shutdown if the workflow was initiated by a push event and the VM was previously deallocated, using the new `pre_status` output.